### PR TITLE
Better options

### DIFF
--- a/src/onnxruntime_easy/__init__.py
+++ b/src/onnxruntime_easy/__init__.py
@@ -209,6 +209,7 @@ def load(
     device: Literal["cpu", "cuda"] = "cpu",
     # TODO: Support device ID
     *,
+    providers: Sequence[str] = (),
     enable_cpu_mem_arena: bool = True,
     enable_mem_pattern: bool = True,
     enable_mem_reuse: bool = True,
@@ -236,7 +237,8 @@ def load(
 
     Args:
         model_path: Path to the model file.
-        device: Device to run the model on. Can be "cpu" or "cuda".
+        device: Device to run the model on. Can be "cpu" or "cuda". Overridden when
+            providers are specified.
 
     Returns:
         An inference session for the model.
@@ -269,7 +271,7 @@ def load(
     return EasySession(
         model_path,
         sess_options=opts,
-        providers=_get_providers(device),
+        providers=providers if providers else _get_providers(device),
         device=device,
         log_severity_level=log_severity_level,
         log_verbosity_level=log_verbosity_level,


### PR DESCRIPTION
This pull request includes several enhancements and fixes to the `src/onnxruntime_easy/__init__.py` file. The changes improve the handling of DLPack-compatible objects, add logging options, and provide more flexibility in specifying providers for the ONNX Runtime session.

Improvements and fixes:

* Added import for `_ort_c` from `onnxruntime.capi._pybind_state` to support new functionalities.

Enhancements to DLPack support:

* Updated `_to_ort_value` function to properly handle DLPack-compatible objects by calling `value.__dlpack__()` and creating an `OrtValue` from it.

Logging options:

* Enhanced the `EasySession` class constructor to include `log_severity_level` and `log_verbosity_level` parameters, and initialized `RunOptions` with these logging settings.

Provider flexibility:

* Added `providers` parameter to the `load` function, allowing users to specify custom providers for the ONNX Runtime session. Updated the function to use the specified providers or default to the device-specific providers. [[1]](diffhunk://#diff-1f3b5c1ce9199de98cda4780da1fc3b64aecbb25a3d2469abfbde0113a71046bR212) [[2]](diffhunk://#diff-1f3b5c1ce9199de98cda4780da1fc3b64aecbb25a3d2469abfbde0113a71046bL256-R277)

Documentation updates:

* Updated the `load` function docstring to reflect the new `providers` parameter and its impact on the `device` parameter.