### PR TITLE
Fix casing for WebGPU execution provider

### DIFF
--- a/src/onnxruntime_easy/__init__.py
+++ b/src/onnxruntime_easy/__init__.py
@@ -178,7 +178,7 @@ def _get_providers(device: str) -> tuple[str, ...]:
     if device == "cuda":
         return ("CUDAExecutionProvider", "CPUExecutionProvider")
     if device == "webgpu":
-        return ("WebGPUExecutionProvider", "CPUExecutionProvider")
+        return ("WebGpuExecutionProvider", "CPUExecutionProvider")
     raise ValueError(f"Unsupported device: {device}")
 
 

--- a/test/onnxruntime_easy/test_apis.py
+++ b/test/onnxruntime_easy/test_apis.py
@@ -54,7 +54,7 @@ class TestGetProviders(unittest.TestCase):
     def test_webgpu(self):
         self.assertEqual(
             _get_providers("webgpu"),
-            ("WebGPUExecutionProvider", "CPUExecutionProvider"),
+            ("WebGpuExecutionProvider", "CPUExecutionProvider"),
         )
 
     def test_unsupported_device(self):


### PR DESCRIPTION
Correct the casing of 'WebGPU' to 'WebGpu' in execution provider return value.